### PR TITLE
Add sampler guards and validate frsr_bin inputs

### DIFF
--- a/R/bin.R
+++ b/R/bin.R
@@ -59,9 +59,49 @@ frsr_bin <- function(x_min = 0.25, x_max = 1.0,
                      float_samples = 1024, magic_samples = 2048,
                      magic_min = 1596980000L,
                      magic_max = 1598050000L) {
+  if (!is.numeric(x_min) || length(x_min) != 1 || !is.finite(x_min)) {
+    stop("`x_min` must be a finite numeric scalar", call. = FALSE)
+  }
+  if (!is.numeric(x_max) || length(x_max) != 1 || !is.finite(x_max)) {
+    stop("`x_max` must be a finite numeric scalar", call. = FALSE)
+  }
+  if (x_min >= x_max) {
+    stop("`x_min` must be strictly less than `x_max`", call. = FALSE)
+  }
+
+  if (!is.numeric(n_bins) || length(n_bins) != 1 || !is.finite(n_bins)) {
+    stop("`n_bins` must be a finite numeric scalar", call. = FALSE)
+  }
+  if (n_bins < 1) {
+    stop("`n_bins` must be at least 1", call. = FALSE)
+  }
+  n_bins <- as.integer(n_bins)
+
+  if (!is.numeric(float_samples) || length(float_samples) != 1 || !is.finite(float_samples) || float_samples < 1) {
+    stop("`float_samples` must be a positive integer", call. = FALSE)
+  }
+  float_samples <- as.integer(float_samples)
+
+  if (!is.numeric(magic_samples) || length(magic_samples) != 1 || !is.finite(magic_samples) || magic_samples < 1) {
+    stop("`magic_samples` must be a positive integer", call. = FALSE)
+  }
+  magic_samples <- as.integer(magic_samples)
+
+  if (!is.numeric(magic_min) || length(magic_min) != 1 || !is.finite(magic_min)) {
+    stop("`magic_min` must be a finite numeric scalar", call. = FALSE)
+  }
+  if (!is.numeric(magic_max) || length(magic_max) != 1 || !is.finite(magic_max)) {
+    stop("`magic_max` must be a finite numeric scalar", call. = FALSE)
+  }
+  magic_min <- as.integer(magic_min)
+  magic_max <- as.integer(magic_max)
+  if (magic_min > magic_max) {
+    stop("`magic_min` must be less than or equal to `magic_max`", call. = FALSE)
+  }
+
   # Divide [x_min, x_max] into evenly spaced bin boundaries
   bin_edges <- seq(x_min, x_max, length.out = n_bins + 1)
-  
+
   # Generate results for each bin
   bins <- lapply(seq_len(n_bins), function(i) {
     bin_min <- bin_edges[i]

--- a/R/bin.R
+++ b/R/bin.R
@@ -59,49 +59,9 @@ frsr_bin <- function(x_min = 0.25, x_max = 1.0,
                      float_samples = 1024, magic_samples = 2048,
                      magic_min = 1596980000L,
                      magic_max = 1598050000L) {
-  if (!is.numeric(x_min) || length(x_min) != 1 || !is.finite(x_min)) {
-    stop("`x_min` must be a finite numeric scalar", call. = FALSE)
-  }
-  if (!is.numeric(x_max) || length(x_max) != 1 || !is.finite(x_max)) {
-    stop("`x_max` must be a finite numeric scalar", call. = FALSE)
-  }
-  if (x_min >= x_max) {
-    stop("`x_min` must be strictly less than `x_max`", call. = FALSE)
-  }
-
-  if (!is.numeric(n_bins) || length(n_bins) != 1 || !is.finite(n_bins)) {
-    stop("`n_bins` must be a finite numeric scalar", call. = FALSE)
-  }
-  if (n_bins < 1) {
-    stop("`n_bins` must be at least 1", call. = FALSE)
-  }
-  n_bins <- as.integer(n_bins)
-
-  if (!is.numeric(float_samples) || length(float_samples) != 1 || !is.finite(float_samples) || float_samples < 1) {
-    stop("`float_samples` must be a positive integer", call. = FALSE)
-  }
-  float_samples <- as.integer(float_samples)
-
-  if (!is.numeric(magic_samples) || length(magic_samples) != 1 || !is.finite(magic_samples) || magic_samples < 1) {
-    stop("`magic_samples` must be a positive integer", call. = FALSE)
-  }
-  magic_samples <- as.integer(magic_samples)
-
-  if (!is.numeric(magic_min) || length(magic_min) != 1 || !is.finite(magic_min)) {
-    stop("`magic_min` must be a finite numeric scalar", call. = FALSE)
-  }
-  if (!is.numeric(magic_max) || length(magic_max) != 1 || !is.finite(magic_max)) {
-    stop("`magic_max` must be a finite numeric scalar", call. = FALSE)
-  }
-  magic_min <- as.integer(magic_min)
-  magic_max <- as.integer(magic_max)
-  if (magic_min > magic_max) {
-    stop("`magic_min` must be less than or equal to `magic_max`", call. = FALSE)
-  }
-
   # Divide [x_min, x_max] into evenly spaced bin boundaries
   bin_edges <- seq(x_min, x_max, length.out = n_bins + 1)
-
+  
   # Generate results for each bin
   bins <- lapply(seq_len(n_bins), function(i) {
     bin_min <- bin_edges[i]

--- a/R/bin.R
+++ b/R/bin.R
@@ -59,6 +59,63 @@ frsr_bin <- function(x_min = 0.25, x_max = 1.0,
                      float_samples = 1024, magic_samples = 2048,
                      magic_min = 1596980000L,
                      magic_max = 1598050000L) {
+  if (!is.numeric(x_min) || length(x_min) != 1L || !is.finite(x_min)) {
+    stop("`x_min` must be a finite numeric scalar", call. = FALSE)
+  }
+  if (!is.numeric(x_max) || length(x_max) != 1L || !is.finite(x_max)) {
+    stop("`x_max` must be a finite numeric scalar", call. = FALSE)
+  }
+  if (x_min >= x_max) {
+    stop("`x_min` must be less than `x_max`", call. = FALSE)
+  }
+
+  if (!is.numeric(n_bins) || length(n_bins) != 1L || is.na(n_bins)) {
+    stop("`n_bins` must be at least 1", call. = FALSE)
+  }
+  n_bins <- as.integer(n_bins)
+  if (is.na(n_bins) || n_bins < 1L) {
+    stop("`n_bins` must be at least 1", call. = FALSE)
+  }
+
+  if (!is.numeric(float_samples) || length(float_samples) != 1L || is.na(float_samples)) {
+    stop("`float_samples` must be at least 1", call. = FALSE)
+  }
+  float_samples <- as.integer(float_samples)
+  if (is.na(float_samples) || float_samples < 1L) {
+    stop("`float_samples` must be at least 1", call. = FALSE)
+  }
+
+  if (!is.numeric(magic_samples) || length(magic_samples) != 1L || is.na(magic_samples)) {
+    stop("`magic_samples` must be at least 1", call. = FALSE)
+  }
+  magic_samples <- as.integer(magic_samples)
+  if (is.na(magic_samples) || magic_samples < 1L) {
+    stop("`magic_samples` must be at least 1", call. = FALSE)
+  }
+
+  if (!is.numeric(magic_min) || length(magic_min) != 1L || !is.finite(magic_min)) {
+    stop("`magic_min` must be a finite integer scalar", call. = FALSE)
+  }
+  if (!is.numeric(magic_max) || length(magic_max) != 1L || !is.finite(magic_max)) {
+    stop("`magic_max` must be a finite integer scalar", call. = FALSE)
+  }
+  magic_min <- as.integer(magic_min)
+  magic_max <- as.integer(magic_max)
+  if (is.na(magic_min) || is.na(magic_max)) {
+    stop("`magic_min` and `magic_max` must be representable as 32-bit integers", call. = FALSE)
+  }
+  if (magic_min > magic_max) {
+    stop("`magic_min` must be less than or equal to `magic_max`", call. = FALSE)
+  }
+
+  if (!is.numeric(NRmax) || length(NRmax) != 1L || !is.finite(NRmax)) {
+    stop("`NRmax` must be a finite numeric scalar", call. = FALSE)
+  }
+  NRmax <- as.integer(NRmax)
+  if (is.na(NRmax) || NRmax < 0L) {
+    stop("`NRmax` must be a non-negative integer", call. = FALSE)
+  }
+
   # Divide [x_min, x_max] into evenly spaced bin boundaries
   bin_edges <- seq(x_min, x_max, length.out = n_bins + 1)
   

--- a/src/sample.cpp
+++ b/src/sample.cpp
@@ -1,8 +1,9 @@
 #include <Rcpp.h>
+#include <bit>
 #include <cmath>
+#include <limits>
 #include <random>
 #include <stdexcept>
-#include <algorithm>
 
 using namespace Rcpp;
 
@@ -17,33 +18,48 @@ constexpr int SignificandMask = (1 << 23) - 1;
 // to float space.
 // [[Rcpp::export]]
 NumericVector boundedStratifiedSample(int n, double low, double high) {
-
+    if (n < 0) {
+        throw std::invalid_argument("`n` must be non-negative");
+    }
+    if (!std::isfinite(low) || !std::isfinite(high)) {
+        throw std::invalid_argument("`low` and `high` must be finite");
+    }
+    if (high <= low) {
+        throw std::invalid_argument("`high` must be greater than `low`");
+    }
     if (low < -126) {
         throw std::invalid_argument("Subnormal numbers are not supported. 'low' must be >= -126");
     }
-    
+
     NumericVector result(n);
-    
+
     std::random_device rd;
     std::mt19937 gen(rd());
     std::uniform_int_distribution<uint32_t> dis(0, std::numeric_limits<uint32_t>::max());
-    
-    int emin = std::ceil(low);
-    int emax = std::ceil(high);
-    
+
+    const double lower_bound = std::exp2(low);
+    const double upper_bound = std::exp2(high);
+
+    int emin = static_cast<int>(std::floor(low));
+    int emax = static_cast<int>(std::ceil(high));
+    int exponent_span = std::max(1, emax - emin);
+
     for (int i = 0; i < n; ++i) {
         float sample;
         // Draw candidate bits and use the leading-zero count to rotate evenly
         // through the exponent range before composing the IEEE-754 float.
         do {
             int e = emax - 1;
-            uint32_t bits = dis(gen);
-            int lz = __builtin_clz(bits);
-            e -= (lz % (emax - emin));
-            
+            uint32_t bits;
+            do {
+                bits = dis(gen);
+            } while (bits == 0);
+            int lz = std::countl_zero(bits);
+            e -= (lz % exponent_span);
+
             uint32_t significand = dis(gen) & SignificandMask;
             sample = FromBits((uint32_t(e + 127) << 23) | significand);
-        } while (sample < std::pow(2.0f, low) || sample >= std::pow(2.0f, high));
+        } while (sample < lower_bound || sample >= upper_bound || !std::isfinite(sample));
 
         result[i] = sample;
         // NumericVector stores doubles; assigning the float promotes it back to

--- a/src/sample.cpp
+++ b/src/sample.cpp
@@ -3,8 +3,6 @@
 #include <random>
 #include <stdexcept>
 #include <algorithm>
-#include <bit>
-#include <limits>
 
 using namespace Rcpp;
 
@@ -24,20 +22,14 @@ NumericVector boundedStratifiedSample(int n, double low, double high) {
         throw std::invalid_argument("Subnormal numbers are not supported. 'low' must be >= -126");
     }
     
-    if (!(low < high)) {
-        throw std::invalid_argument("'low' must be strictly less than 'high'");
-    }
-
     NumericVector result(n);
-
+    
     std::random_device rd;
     std::mt19937 gen(rd());
-    std::uniform_int_distribution<uint32_t> exponent_draw(1, std::numeric_limits<uint32_t>::max());
-    std::uniform_int_distribution<uint32_t> significand_draw(0, SignificandMask);
-
+    std::uniform_int_distribution<uint32_t> dis(0, std::numeric_limits<uint32_t>::max());
+    
     int emin = std::ceil(low);
     int emax = std::ceil(high);
-    int exponent_span = std::max(1, emax - emin);
     
     for (int i = 0; i < n; ++i) {
         float sample;
@@ -45,11 +37,11 @@ NumericVector boundedStratifiedSample(int n, double low, double high) {
         // through the exponent range before composing the IEEE-754 float.
         do {
             int e = emax - 1;
-            uint32_t bits = exponent_draw(gen);
-            int lz = std::countl_zero(bits);
-            e -= (lz % exponent_span);
-
-            uint32_t significand = significand_draw(gen);
+            uint32_t bits = dis(gen);
+            int lz = __builtin_clz(bits);
+            e -= (lz % (emax - emin));
+            
+            uint32_t significand = dis(gen) & SignificandMask;
             sample = FromBits((uint32_t(e + 127) << 23) | significand);
         } while (sample < std::pow(2.0f, low) || sample >= std::pow(2.0f, high));
 

--- a/tests/testthat/test-bin.R
+++ b/tests/testthat/test-bin.R
@@ -9,3 +9,27 @@ test_that("frsr_bin handles different number of bins", {
   result <- frsr_bin(n_bins = 8, float_samples = 10, magic_samples = 10)
   expect_equal(nrow(result), 8)
 })
+
+test_that("frsr_bin validates parameters", {
+  expect_error(frsr_bin(x_min = 1, x_max = 1), "`x_min` must be strictly less")
+  expect_error(frsr_bin(x_min = 0.5, x_max = 0.25), "`x_min` must be strictly less")
+  expect_error(frsr_bin(n_bins = 0), "`n_bins` must be at least 1")
+  expect_error(frsr_bin(magic_min = 10L, magic_max = 5L), "`magic_min` must be less than or equal")
+})
+
+test_that("frsr_bin returns expected bin metadata and magic bounds", {
+  x_min <- 0.25
+  x_max <- 1
+  n_bins <- 4
+  magic_min <- 1596980000L
+  magic_max <- 1596980100L
+  result <- frsr_bin(x_min = x_min, x_max = x_max,
+                     n_bins = n_bins, float_samples = 32, magic_samples = 32,
+                     magic_min = magic_min, magic_max = magic_max)
+
+  edges <- seq(x_min, x_max, length.out = n_bins + 1)
+  expect_equal(result$Range_Min, head(edges, -1))
+  expect_equal(result$Range_Max, tail(edges, -1))
+  expect_true(all(result$Magic >= magic_min))
+  expect_true(all(result$Magic <= magic_max))
+})

--- a/tests/testthat/test-bin.R
+++ b/tests/testthat/test-bin.R
@@ -11,10 +11,17 @@ test_that("frsr_bin handles different number of bins", {
 })
 
 test_that("frsr_bin validates parameters", {
-  expect_error(frsr_bin(x_min = 1, x_max = 1), "`x_min` must be strictly less")
-  expect_error(frsr_bin(x_min = 0.5, x_max = 0.25), "`x_min` must be strictly less")
-  expect_error(frsr_bin(n_bins = 0), "`n_bins` must be at least 1")
-  expect_error(frsr_bin(magic_min = 10L, magic_max = 5L), "`magic_min` must be less than or equal")
+  expect_error(
+    frsr_bin(n_bins = 0),
+    "`n_bins` must be at least 1",
+    fixed = TRUE
+  )
+
+  expect_error(
+    frsr_bin(magic_min = 1596980100L, magic_max = 1596980000L),
+    "`magic_min` must be less than or equal to `magic_max`",
+    fixed = TRUE
+  )
 })
 
 test_that("frsr_bin returns expected bin metadata and magic bounds", {
@@ -23,9 +30,16 @@ test_that("frsr_bin returns expected bin metadata and magic bounds", {
   n_bins <- 4
   magic_min <- 1596980000L
   magic_max <- 1596980100L
-  result <- frsr_bin(x_min = x_min, x_max = x_max,
-                     n_bins = n_bins, float_samples = 32, magic_samples = 32,
-                     magic_min = magic_min, magic_max = magic_max)
+
+  result <- frsr_bin(
+    x_min = x_min,
+    x_max = x_max,
+    n_bins = n_bins,
+    float_samples = 32,
+    magic_samples = 32,
+    magic_min = magic_min,
+    magic_max = magic_max
+  )
 
   edges <- seq(x_min, x_max, length.out = n_bins + 1)
   expect_equal(result$Range_Min, head(edges, -1))

--- a/tests/testthat/test-sample.R
+++ b/tests/testthat/test-sample.R
@@ -33,9 +33,30 @@ test_that("frsr_sample returns correct structure", {
 test_that("boundedStratifiedSample handles narrow exponent ranges", {
     low <- log2(0.75)
     high <- log2(1)
-    samples <- .Call("_frsrr_boundedStratifiedSample", PACKAGE = "frsrr", 32L, low, high)
+
+    samples <- .Call(
+        "_frsrr_boundedStratifiedSample",
+        PACKAGE = "frsrr",
+        32L,
+        low,
+        high
+    )
+
     expect_length(samples, 32)
     expect_true(all(is.finite(samples)))
     expect_true(all(samples >= 0.75))
     expect_true(all(samples < 1))
+})
+
+test_that("boundedStratifiedSample tolerates zero bit draws", {
+    samples <- .Call(
+        "_frsrr_boundedStratifiedSample",
+        PACKAGE = "frsrr",
+        1024L,
+        log2(0.25),
+        log2(0.5)
+    )
+
+    expect_length(samples, 1024)
+    expect_true(all(is.finite(samples)))
 })

--- a/tests/testthat/test-sample.R
+++ b/tests/testthat/test-sample.R
@@ -29,3 +29,13 @@ test_that("frsr_sample returns correct structure", {
     result <- frsr_sample(4)
     expect_true(all(c("input", "initial", "after_one", "final", "error", "enre", "diff", "iters") %in% names(result)))
 })
+
+test_that("boundedStratifiedSample handles narrow exponent ranges", {
+    low <- log2(0.75)
+    high <- log2(1)
+    samples <- .Call("_frsrr_boundedStratifiedSample", PACKAGE = "frsrr", 32L, low, high)
+    expect_length(samples, 32)
+    expect_true(all(is.finite(samples)))
+    expect_true(all(samples >= 0.75))
+    expect_true(all(samples < 1))
+})


### PR DESCRIPTION
## Summary
- harden the bounded stratified sampler against empty exponent spans and zero-valued draws
- validate user inputs in `frsr_bin` before delegating to the native helpers
- extend the test suite to cover sampler edge cases, parameter validation, and bin metadata

## Testing
- Not run (Rscript unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_690d281002ec8322882414e0d7810490