### PR TITLE
Refactor API 

### DIFF
--- a/R/bin.R
+++ b/R/bin.R
@@ -3,7 +3,7 @@
 #' @importFrom RcppParallel RcppParallelLibs
 NULL
 
-#' FRSR Bin
+#' FRSR Binned Search
 #'
 #' Generate optimal magic constants for the Fast Reciprocal Square Root algorithm over specified bins
 #' by minimizing the maximum relative error. 
@@ -41,7 +41,7 @@ NULL
 #' @examples
 #' \donttest{
 #' # Generate optimal magic constants for the range [0.25, 1.0] divided into 4 bins
-#' result <- frsr_bin()
+#' result <- frsr_search_binned()
 #' print(result)
 #' #   Location Range_Min Range_Max      Magic    Sum_Error N_bins
 #' # 1        1 0.2500000 0.3535534 1597413411 4.549199e-04      4
@@ -49,16 +49,16 @@ NULL
 #' # 3        3 0.5000000 0.7071068 1597150657 3.486200e-05      4
 #' # 4        4 0.7071068 1.0000000 1597488127 8.389181e-04      4
 #' # }
-#' @name frsr_bin
+#' @name frsr_search_binned
 NULL
 
-#' @rdname frsr_bin
+#' @rdname frsr_search_binned
 #' @export
-frsr_bin <- function(x_min = 0.25, x_max = 1.0,
-                     n_bins = 4, NRmax = 0,
-                     float_samples = 1024, magic_samples = 2048,
-                     magic_min = 1596980000L,
-                     magic_max = 1598050000L) {
+frsr_search_binned <- function(x_min = 0.25, x_max = 1.0,
+                               n_bins = 4, NRmax = 0,
+                               float_samples = 1024, magic_samples = 2048,
+                               magic_min = 1596980000L,
+                               magic_max = 1598050000L) {
   if (!is.numeric(x_min) || length(x_min) != 1L || !is.finite(x_min)) {
     stop("`x_min` must be a finite numeric scalar", call. = FALSE)
   }
@@ -156,4 +156,24 @@ frsr_bin <- function(x_min = 0.25, x_max = 1.0,
     "Max_Relative_Error",
     "Avg_Relative_Error"
   )]
+}
+
+#' @rdname frsr_search_binned
+#' @export
+frsr_bin <- function(x_min = 0.25, x_max = 1.0,
+                     n_bins = 4, NRmax = 0,
+                     float_samples = 1024, magic_samples = 2048,
+                     magic_min = 1596980000L,
+                     magic_max = 1598050000L) {
+  .Deprecated("frsr_search_binned", package = "frsrr")
+  frsr_search_binned(
+    x_min = x_min,
+    x_max = x_max,
+    n_bins = n_bins,
+    NRmax = NRmax,
+    float_samples = float_samples,
+    magic_samples = magic_samples,
+    magic_min = magic_min,
+    magic_max = magic_max
+  )
 }

--- a/R/frsr.R
+++ b/R/frsr.R
@@ -17,7 +17,7 @@ NULL
 #' @param keep_params Logical. If \code{TRUE}, generation parameters are included in detailed output. Default is \code{FALSE}.
 #'
 #' @return
-#' \code{frsr} returns a numeric vector of \code{length(x)}.
+#' \code{frsr_compute} returns a numeric vector of \code{length(x)}.
 #'
 #' If \code{detail = TRUE}, returns a data frame of \code{length(x)} rows with columns:
 #'     \item{input}{The input values}
@@ -76,13 +76,13 @@ NULL
 #' @examples
 #' \donttest{
 #' # Custom Newton-Raphson parameters
-#' result <- frsr(c(1, 4, 9, 16), magic = 0x5f375a86, NRmax = 2, A = 1.6, B = 0.6)
+#' result <- frsr_compute(c(1, 4, 9, 16), magic = 0x5f375a86, NRmax = 2, A = 1.6, B = 0.6)
 #' ## result is a vector of length 4
 #' print(result)
 #' # [1] 0.9990148 0.4995074 0.3337626 0.2497537
 #'
 #' # Optional detail
-#' result.df <- frsr(c(pi, 2^-31, 0.4, 6.02e23), detail = TRUE)
+#' result.df <- frsr_compute(c(pi, 2^-31, 0.4, 6.02e23), detail = TRUE)
 #' ## result.df is a dataframe with 4 rows and 8 columns
 #' print(result.df)
 #' #         input      initial    after_one        final        error         enre          diff iters
@@ -91,14 +91,14 @@ NULL
 #' # 3 4.000000e-01 1.632430e+00 1.578616e+00 1.578616e+00 0.0015955754 0.0015955754 -5.381417e-02     1
 #' # 4 6.020000e+23 1.306493e-12 1.288484e-12 1.288484e-12 0.0002823969 0.0002823969 -1.800925e-14     1
 #' # }
-#' @name frsr
+#' @name frsr_compute
 NULL
 
-#' @rdname frsr
+#' @rdname frsr_compute
 #' @export
-frsr <- function(x, magic = 0x5f3759df, NRmax = 1,
-                 A = 1.5, B = 0.5, tol = 0,
-                 detail = FALSE, keep_params = FALSE) {
+frsr_compute <- function(x, magic = 0x5f3759df, NRmax = 1,
+                         A = 1.5, B = 0.5, tol = 0,
+                         detail = FALSE, keep_params = FALSE) {
   arg_df <- data.frame(x = x, magic = magic,
                        NRmax = NRmax, tol = tol,
                        A = A, B = B)
@@ -109,4 +109,14 @@ frsr <- function(x, magic = 0x5f3759df, NRmax = 1,
   } else {
     return(result$final)
   }
+}
+
+#' @rdname frsr_compute
+#' @export
+frsr <- function(x, magic = 0x5f3759df, NRmax = 1,
+                 A = 1.5, B = 0.5, tol = 0,
+                 detail = FALSE, keep_params = FALSE) {
+  frsr_compute(x = x, magic = magic, NRmax = NRmax,
+               A = A, B = B, tol = tol,
+               detail = detail, keep_params = keep_params)
 }

--- a/R/nr.R
+++ b/R/nr.R
@@ -19,9 +19,9 @@
 #'    \item{iters}{Number of iterations performed}
 #'
 #' @details
-#' While \code{frsr} uses C++ internally, this is difficult to do when 
+#' While \code{frsr_compute} uses C++ internally, this is difficult to do when
 #' allowing the user to set a custom formula in an R-like idiom. This
-#' function will be much slower than \code{frsr}.
+#' function will be much slower than \code{frsr_compute}.
 #' 
 #' When \eqn{(A - B * x * y_n^2)} is the formula, B = A - 1
 #' must be true to ensure convergence. If you supply a different iteration step,
@@ -36,18 +36,18 @@
 #' \donttest{
 #' x <- c(1, 4, 9, 16)
 #' ex_formula <- quote(y * (1.5 - 0.5 * x * y^2))
-#' result <- frsr_NR(x, formula = ex_formula)
+#' result <- frsr_newton_custom(x, formula = ex_formula)
 #' print(result$final)
 #' # [1] 0.9990148 0.4995074 0.3337626 0.2497537
 #' }
 #' 
-#' @name frsr_NR
+#' @name frsr_newton_custom
 NULL
 
-#' @rdname frsr_NR
+#' @rdname frsr_newton_custom
 #' @export
-frsr_NR <- function(x, magic = 0x5f3759df, formula, NRmax = 1, tol = 0) {
-  y <- frsr(x, magic, NRmax = 0)
+frsr_newton_custom <- function(x, magic = 0x5f3759df, formula, NRmax = 1, tol = 0) {
+  y <- frsr_compute(x, magic, NRmax = 0)
   reference <- 1 / sqrt(x)
   iter <- 0
   initial <- y
@@ -82,4 +82,11 @@ frsr_NR <- function(x, magic = 0x5f3759df, formula, NRmax = 1, tol = 0) {
     conv_rate = (error_initial - error) / iter,
     iters = iter
   )
+}
+
+#' @rdname frsr_newton_custom
+#' @export
+frsr_NR <- function(x, magic = 0x5f3759df, formula, NRmax = 1, tol = 0) {
+  .Deprecated("frsr_newton_custom", package = "frsrr")
+  frsr_newton_custom(x = x, magic = magic, formula = formula, NRmax = NRmax, tol = tol)
 }

--- a/R/sample.R
+++ b/R/sample.R
@@ -11,7 +11,7 @@ NULL
 #' @param magic_max Maximum value for the magic number range. Default is \code{1598050000L}
 #' @param x_min Minimum value for the input range. Default is \code{0.25}
 #' @param x_max Maximum value for the input range. Default is \code{1.0}
-#' @param ... Additional arguments passed to \code{frsr}.
+#' @param ... Additional arguments passed to \code{frsr_compute}.
 #'
 #' @details 
 #' 
@@ -28,7 +28,7 @@ NULL
 #'
 #' @return
 #' A data frame with \code{n} rows. When \code{keep_params = FALSE} (the default), the
-#' columns match \code{frsr(..., detail = TRUE)}:
+#' columns match \code{frsr_compute(..., detail = TRUE)}:
 #'     \item{input}{Sampled input values}
 #'     \item{initial}{Initial approximation from integer operations}
 #'     \item{after_one}{Result after one Newton-Raphson iteration}
@@ -45,9 +45,9 @@ NULL
 #'     \item{B}{Newton-Raphson parameter B}
 #'     \item{tol}{Specified tolerance}
 #' 
-#' @seealso 
-#' 
-#' \code{\link{frsr}}
+#' @seealso
+#'
+#' \code{\link{frsr_compute}}
 #'
 #' @references
 #'
@@ -96,6 +96,6 @@ frsr_sample <- function(n,
           PACKAGE = 'frsrr',
           n, log2(x_min), log2(x_max))
     }
-    # Call frsr with generated inputs and parameters
-    frsr(x = inputs, magic = magic_numbers, detail = TRUE, ...)
+    # Call frsr_compute with generated inputs and parameters
+    frsr_compute(x = inputs, magic = magic_numbers, detail = TRUE, ...)
 }

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ I like R! R doesn't have a type for 32 bit floats, so I wanted a way to mess wit
 - C++ parallel implementation for speed so you can get the wrong answer faster
 - Fast sampler to ease sampling over parameter ranges
 - Optional detailed output including initial approximation, intermediate steps, and error metrics
-- Ability to run the frsr with a custom iteration formula, specified in R formula syntax
+- Ability to run the frsr_compute routine with a custom iteration formula, specified in R formula syntax
 - Bin input range and compute optimal magic constants for each bin, if efficiency really isn't your thing.
 
 ## Installation
@@ -32,13 +32,13 @@ devtools::install_github("Protonk/frsrr")
 library(frsrr)
 
 # Custom parameters
-result <- frsr(c(1, 4, 9, 16), magic = 0x5f375a86, NRmax = 2, A = 1.6, B = 0.6)
+result <- frsr_compute(c(1, 4, 9, 16), magic = 0x5f375a86, NRmax = 2, A = 1.6, B = 0.6)
 ## result is a vector of length 4
 print(result)
 # [1] 0.9990148 0.4995074 0.3337626 0.2497537
 
 # Optional detail 
-result.df <- frsr(c(pi, 2^-31, 0.4, 6.02e23), detail = TRUE)
+result.df <- frsr_compute(c(pi, 2^-31, 0.4, 6.02e23), detail = TRUE)
 ## result.df is a dataframe with 4 rows and 7 columns
 print(result)
 #          input      initial    after_one        final        error          diff iters
@@ -61,7 +61,7 @@ kable(samples, format = "simple")
 #  0.9425029   0.9680235    1.024561   1.024561   0.0053300    0.0565371       1   1597011026       1   1.5   0.5     0
 
 ## Find optimal constant for 4 bins betweeon 0.25 and 1.0
-bins <-  frsr_bin(n_bins = 4)
+bins <-  frsr_search_binned(n_bins = 4)
 kable(bins, format = "simple")
 #  Location   Range_Min   Range_Max        Magic   Avg_Relative_Error   Max_Relative_Error    N
 # ---------  ----------  ----------  -----------  -------------------  -------------------  ---

--- a/tests/testthat/test-bin.R
+++ b/tests/testthat/test-bin.R
@@ -1,5 +1,5 @@
-test_that("frsr_bin returns documented columns", {
-  result <- frsr_bin(float_samples = 8, magic_samples = 8)
+test_that("frsr_search_binned returns documented columns", {
+  result <- frsr_search_binned(float_samples = 8, magic_samples = 8)
   expected_cols <- c(
     "N_bins",
     "Location",
@@ -16,35 +16,35 @@ test_that("frsr_bin returns documented columns", {
   expect_identical(unique(result$N_bins), 4L)
 })
 
-test_that("frsr_bin handles different number of bins", {
-  result <- frsr_bin(n_bins = 2, float_samples = 10, magic_samples = 10)
+test_that("frsr_search_binned handles different number of bins", {
+  result <- frsr_search_binned(n_bins = 2, float_samples = 10, magic_samples = 10)
   expect_equal(nrow(result), 2)
-  result <- frsr_bin(n_bins = 8, float_samples = 10, magic_samples = 10)
+  result <- frsr_search_binned(n_bins = 8, float_samples = 10, magic_samples = 10)
   expect_equal(nrow(result), 8)
 })
 
-test_that("frsr_bin validates parameters", {
+test_that("frsr_search_binned validates parameters", {
   expect_error(
-    frsr_bin(n_bins = 0),
+    frsr_search_binned(n_bins = 0),
     "`n_bins` must be at least 1",
     fixed = TRUE
   )
 
   expect_error(
-    frsr_bin(magic_min = 1596980100L, magic_max = 1596980000L),
+    frsr_search_binned(magic_min = 1596980100L, magic_max = 1596980000L),
     "`magic_min` must be less than or equal to `magic_max`",
     fixed = TRUE
   )
 })
 
-test_that("frsr_bin returns expected bin metadata and magic bounds", {
+test_that("frsr_search_binned returns expected bin metadata and magic bounds", {
   x_min <- 0.25
   x_max <- 1
   n_bins <- 4
   magic_min <- 1596980000L
   magic_max <- 1596980100L
 
-  result <- frsr_bin(
+  result <- frsr_search_binned(
     x_min = x_min,
     x_max = x_max,
     n_bins = n_bins,

--- a/tests/testthat/test-frsr.R
+++ b/tests/testthat/test-frsr.R
@@ -1,5 +1,5 @@
 test_that("detail argument produces expected output structure", {
-  result <- frsr(c(1, 4, 9), detail = TRUE)
+  result <- frsr_compute(c(1, 4, 9), detail = TRUE)
   expected_cols <- c(
     "input",
     "initial",
@@ -16,53 +16,53 @@ test_that("detail argument produces expected output structure", {
   expect_equal(nrow(result), 3)
   expect_true(all(vapply(result, is.numeric, logical(1))))
 
-  result.vec <- frsr(c(1, 4, 9))
+  result.vec <- frsr_compute(c(1, 4, 9))
   expect_equal(length(result.vec), 3)
 })
 
-test_that("frsr respects custom parameters", {
-  result1 <- frsr(4, magic = 0x5f375a86, NRmax = 2)
-  result2 <- frsr(4)
+test_that("frsr_compute respects custom parameters", {
+  result1 <- frsr_compute(4, magic = 0x5f375a86, NRmax = 2)
+  result2 <- frsr_compute(4)
   expect_false(isTRUE(all.equal(result1, result2)))
 
-  result3 <- frsr(4, A = 3.6, B = 0.2)
+  result3 <- frsr_compute(4, A = 3.6, B = 0.2)
   expect_false(isTRUE(all.equal(result3, result2)))
 
-  result3_detail <- frsr(4, A = 3.6, B = 0.2, detail = TRUE)
+  result3_detail <- frsr_compute(4, A = 3.6, B = 0.2, detail = TRUE)
   expect_false(isTRUE(all.equal(result3_detail$final, result1)))
 })
 
-test_that("frsr handles vector input", {
-  result.vec <- frsr(c(1, 4, 9, 16))
+test_that("frsr_compute handles vector input", {
+  result.vec <- frsr_compute(c(1, 4, 9, 16))
   expect_equal(length(result.vec), 4)
   expect_equal(result.vec, 1/sqrt(c(1, 4, 9, 16)), tolerance = 1e-2)
-  # frsr
-  result <- frsr(c(1, 4, 9, 16), detail = TRUE)
+  # frsr_compute with detail
+  result <- frsr_compute(c(1, 4, 9, 16), detail = TRUE)
   expect_equal(nrow(result), 4)
   expect_equal(result$final, 1/sqrt(c(1, 4, 9, 16)), tolerance = 1e-2)
 })
 
-test_that("frsr respects tolerance parameter", {
+test_that("frsr_compute respects tolerance parameter", {
   # iterates to NRmax with tol = 0
-  result1 <- frsr(0.0125, tol = 0, NRmax = 20, detail = TRUE)
-  result2 <- frsr(0.0125, tol = 1e-7, NRmax = 20, detail = TRUE)
+  result1 <- frsr_compute(0.0125, tol = 0, NRmax = 20, detail = TRUE)
+  result2 <- frsr_compute(0.0125, tol = 1e-7, NRmax = 20, detail = TRUE)
   expect_true(result2$iters[1] < result1$iters[1])
 })
 
-test_that("frsr produces accurate results with tolerance parameter", {
-  result_vec <- frsr(4, tol = 1e-6, NRmax = 6)
+test_that("frsr_compute produces accurate results with tolerance parameter", {
+  result_vec <- frsr_compute(4, tol = 1e-6, NRmax = 6)
   expect_equal(result_vec, 1/sqrt(4), tolerance = 1e-6)
 })
 
-test_that("frsr default returns a numeric vector", {
+test_that("frsr_compute default returns a numeric vector", {
   # Test with a single value
-  result_single <- frsr(4)
+  result_single <- frsr_compute(4)
   expect_type(result_single, "double")
   expect_length(result_single, 1)
 
   # Test with multiple values
   input_vector <- c(1, 4, 9, 16)
-  result_multiple <- frsr(input_vector)
+  result_multiple <- frsr_compute(input_vector)
   expect_type(result_multiple, "double")
   expect_length(result_multiple, length(input_vector))
 
@@ -71,16 +71,16 @@ test_that("frsr default returns a numeric vector", {
   expect_false(is.list(result_multiple))
   expect_false(is.data.frame(result_multiple))
   # with detail param set to TRUE we expect a data frame
-  result_single_detail <- frsr(4, detail = TRUE)
+  result_single_detail <- frsr_compute(4, detail = TRUE)
   expect_s3_class(result_single_detail, "data.frame")
   expect_equal(nrow(result_single_detail), 1)
 
-  result_multiple_detail <- frsr(input_vector, detail = TRUE)
+  result_multiple_detail <- frsr_compute(input_vector, detail = TRUE)
   expect_s3_class(result_multiple_detail, "data.frame")
   expect_equal(nrow(result_multiple_detail), length(input_vector))
 })
 
-test_that("frsr toggles parameter columns according to keep_params", {
+test_that("frsr_compute toggles parameter columns according to keep_params", {
   base_cols <- c(
     "input",
     "initial",
@@ -93,9 +93,9 @@ test_that("frsr toggles parameter columns according to keep_params", {
   )
   param_cols <- c("magic", "NRmax", "A", "B", "tol")
 
-  result_with <- frsr(4, keep_params = TRUE, detail = TRUE)
+  result_with <- frsr_compute(4, keep_params = TRUE, detail = TRUE)
   expect_identical(names(result_with), c(base_cols, param_cols))
 
-  result_without <- frsr(4, keep_params = FALSE, detail = TRUE)
+  result_without <- frsr_compute(4, keep_params = FALSE, detail = TRUE)
   expect_identical(names(result_without), base_cols)
 })

--- a/tests/testthat/test-nr.R
+++ b/tests/testthat/test-nr.R
@@ -1,41 +1,41 @@
 # FILE: tests/testthat/test-nr.R
 
-test_that("frsr_NR works with standard formula", {
+test_that("frsr_newton_custom works with standard formula", {
     x <- c(1, 4, 9, 16)
     guess <- c(1, 0.5, 0.333, 0.25)
     formula <- quote(y * (1.5 - 0.5 * x * y^2))
-    result <- frsr_NR(x, formula = formula, NRmax = 1)
-    expect_equal(result$final, frsr(x), tolerance = 1e-2)
+    result <- frsr_newton_custom(x, formula = formula, NRmax = 1)
+    expect_equal(result$final, frsr_compute(x), tolerance = 1e-2)
 })
 
-test_that("frsr_NR works with different formulae", {
+test_that("frsr_newton_custom works with different formulae", {
     x <- c(1, 4, 9, 16)
     ## not likely to be accurate, but should return a result
-    wrong <- frsr_NR(x, formula = quote(y * (1.4 - 0.4 * x - y^2)), NRmax = 1)
+    wrong <- frsr_newton_custom(x, formula = quote(y * (1.4 - 0.4 * x - y^2)), NRmax = 1)
     ## just to make sure we're not bamboozling ourselves
     std_formula <- quote(y * (1.5 - 0.5 * x * y^2))
-    std_result <- frsr_NR(x, formula = std_formula, NRmax = 1)
+    std_result <- frsr_newton_custom(x, formula = std_formula, NRmax = 1)
     expect_false(isTRUE(abs(wrong$final - std_result$final) < 1e-3))
 })
 
-test_that("frsr_NR works with default parameters", {
+test_that("frsr_newton_custom works with default parameters", {
     x <- c(1, 4, 9, 16)
     formula <- quote(y * (1.5 - 0.5 * x * y^2))
-    result <- frsr_NR(x, formula = formula)
-    expect_equal(result$final, frsr(x), tolerance = 1e-2)
+    result <- frsr_newton_custom(x, formula = formula)
+    expect_equal(result$final, frsr_compute(x), tolerance = 1e-2)
 })
 
-test_that("frsr_NR works with multiple iterations", {
+test_that("frsr_newton_custom works with multiple iterations", {
     x <- c(1, 4, 9, 16)
     formula <- quote(y * (1.5 - 0.5 * x * y^2))
-    result <- frsr_NR(x, formula = formula, NRmax = 5)
-    expect_equal(result$final, frsr(x, NRmax = 5), tolerance = 1e-3)
+    result <- frsr_newton_custom(x, formula = formula, NRmax = 5)
+    expect_equal(result$final, frsr_compute(x, NRmax = 5), tolerance = 1e-3)
 })
 
-test_that("frsr_NR produces expected output structure", {
+test_that("frsr_newton_custom produces expected output structure", {
     x <- c(1, 4, 9, 16)
     formula <- quote(y * (1.5 - 0.5 * x * y^2))
-    result <- frsr_NR(x, formula = formula)
+    result <- frsr_newton_custom(x, formula = formula)
     expect_s3_class(result, "data.frame")
     expect_equal(nrow(result), length(x))
     expect_identical(


### PR DESCRIPTION
## Summary
- rename the primary evaluator to `frsr_compute()` and add compatibility wrappers for the legacy `frsr()` entry point
- retitle the binned search helper to `frsr_search_binned()` and provide a deprecated `frsr_bin()` alias
- rename the Newton-Raphson accessor to `frsr_newton_custom()` with a deprecated `frsr_NR()` wrapper and update documentation, README examples, and tests to use the new names

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e46acfe4883229f8433a668a9b0f1)