### PR TITLE
Implement reproducible float32 sampler

### DIFF
--- a/R/bin.R
+++ b/R/bin.R
@@ -15,6 +15,9 @@ NULL
 #' @param magic_samples Integer. The number of magic constant samples to generate per bin.
 #' @param magic_min Integer. The minimum magic constant to test (default: 1596980000).
 #' @param magic_max Integer. The maximum magic constant to test (default: 1598050000).
+#' @param weighted Logical; if \code{TRUE}, weight the float sampler by the
+#'   number of representable significands in each exponent stratum. Default is
+#'   \code{FALSE}.
 #' @param NRmax Integer. The maximum number of Newton-Raphson iterations (default: 0).
 #'
 #' @return
@@ -58,7 +61,8 @@ frsr_bin <- function(x_min = 0.25, x_max = 1.0,
                      n_bins = 4, NRmax = 0,
                      float_samples = 1024, magic_samples = 2048,
                      magic_min = 1596980000L,
-                     magic_max = 1598050000L) {
+                     magic_max = 1598050000L,
+                     weighted = FALSE) {
   if (!is.numeric(x_min) || length(x_min) != 1L || !is.finite(x_min)) {
     stop("`x_min` must be a finite numeric scalar", call. = FALSE)
   }
@@ -116,6 +120,10 @@ frsr_bin <- function(x_min = 0.25, x_max = 1.0,
     stop("`NRmax` must be a non-negative integer", call. = FALSE)
   }
 
+  if (!is.logical(weighted) || length(weighted) != 1L || is.na(weighted)) {
+    stop("`weighted` must be a non-missing logical scalar", call. = FALSE)
+  }
+
   # Divide [x_min, x_max] into evenly spaced bin boundaries
   bin_edges <- seq(x_min, x_max, length.out = n_bins + 1)
   
@@ -126,7 +134,7 @@ frsr_bin <- function(x_min = 0.25, x_max = 1.0,
     # Pass exponent bounds because the sampler stratifies floats by log2 exponent range
     floats <- .Call('_frsrr_boundedStratifiedSample',
                     PACKAGE = 'frsrr',
-                    float_samples, log2(bin_min), log2(bin_max))
+                    float_samples, log2(bin_min), log2(bin_max), weighted)
     magics <- sample(magic_min:magic_max,
                      size = magic_samples,
                      replace = TRUE)

--- a/src/sample.cpp
+++ b/src/sample.cpp
@@ -2,22 +2,20 @@
 #include <bit>
 #include <cmath>
 #include <limits>
-#include <random>
 #include <stdexcept>
+#include <vector>
+#include <algorithm>
 
 using namespace Rcpp;
 
 // Utility functions
-inline uint32_t ToBits(float f) { return std::bit_cast<uint32_t>(f); }
 inline float FromBits(uint32_t b) { return std::bit_cast<float>(b); }
-inline int Exponent(float f) { return ((ToBits(f) >> 23) & 0xff) - 127; }
-constexpr int SignificandMask = (1 << 23) - 1;
 
 // Accept log2 exponent bounds even though they arrive as doubles. Allowing
 // fractional exponents gives callers partially open intervals when mapping back
 // to float space.
 // [[Rcpp::export]]
-NumericVector boundedStratifiedSample(int n, double low, double high) {
+NumericVector boundedStratifiedSample(int n, double low, double high, bool weighted = false) {
     if (n < 0) {
         throw std::invalid_argument("`n` must be non-negative");
     }
@@ -27,43 +25,128 @@ NumericVector boundedStratifiedSample(int n, double low, double high) {
     if (high <= low) {
         throw std::invalid_argument("`high` must be greater than `low`");
     }
-    if (low < -126) {
-        throw std::invalid_argument("Subnormal numbers are not supported. 'low' must be >= -126");
+    if (low < -126 || high > 128) {
+        throw std::invalid_argument("Bounds must satisfy -126 <= low < high <= 128");
     }
+
+    const long double lower_bound = static_cast<long double>(std::exp2(low));
+    const long double upper_bound = static_cast<long double>(std::exp2(high));
+
+    struct Stratum {
+        int exponent;
+        uint32_t smin;
+        uint32_t smax;
+        uint32_t count;
+    };
+
+    constexpr uint32_t SigCount = 1u << 23;
+    const long double SigCountLD = static_cast<long double>(SigCount);
+    const int emin = std::max(-126, static_cast<int>(std::floor(low)));
+    const int emax = std::min(127, static_cast<int>(std::ceil(high)) - 1);
+
+    std::vector<Stratum> strata;
+    strata.reserve(std::max(0, emax - emin + 1));
+
+    for (int e = emin; e <= emax; ++e) {
+        long double twoe = std::ldexp(1.0L, e);
+
+        uint32_t smin = 0u;
+        if (e == emin) {
+            long double ratio = lower_bound / twoe - 1.0L;
+            if (ratio > 0.0L) {
+                long double val = std::ceil(ratio * SigCountLD);
+                if (val >= SigCountLD) {
+                    continue;
+                }
+                if (val < 0.0L) {
+                    val = 0.0L;
+                }
+                smin = static_cast<uint32_t>(val);
+            }
+        }
+
+        uint32_t smax = SigCount - 1u;
+        if (e == emax) {
+            long double ratio = upper_bound / twoe - 1.0L;
+            long double val = std::floor(ratio * SigCountLD) - 1.0L;
+            if (val < 0.0L) {
+                continue;
+            }
+            if (val > SigCountLD - 1.0L) {
+                val = SigCountLD - 1.0L;
+            }
+            smax = static_cast<uint32_t>(val);
+        }
+
+        if (smax < smin) {
+            continue;
+        }
+
+        strata.push_back(Stratum{e, smin, smax, static_cast<uint32_t>(smax - smin + 1)});
+    }
+
+    if (strata.empty()) {
+        if (n == 0) {
+            return NumericVector(0);
+        }
+        throw std::runtime_error("No admissible float32 strata within the requested bounds");
+    }
+
+    RNGScope scope;
 
     NumericVector result(n);
 
-    std::random_device rd;
-    std::mt19937 gen(rd());
-    std::uniform_int_distribution<uint32_t> dis(0, std::numeric_limits<uint32_t>::max());
+    auto sample_offset = [&](uint32_t range) -> uint32_t {
+        if (range == 0u) {
+            return 0u;
+        }
+        double u = unif_rand();
+        double scaled = u * static_cast<double>(range);
+        uint32_t draw = static_cast<uint32_t>(scaled);
+        if (draw >= range) {
+            draw = range - 1u;
+        }
+        return draw;
+    };
 
-    const double lower_bound = std::exp2(low);
-    const double upper_bound = std::exp2(high);
+    if (!weighted) {
+        const std::size_t k = strata.size();
+        const std::size_t start = sample_offset(static_cast<uint32_t>(k));
+        for (int i = 0; i < n; ++i) {
+            const Stratum& st = strata[(start + static_cast<std::size_t>(i)) % k];
+            uint32_t range = st.count;
+            uint32_t step = sample_offset(range);
+            uint32_t significand = st.smin + step;
+            uint32_t bits = (static_cast<uint32_t>(st.exponent + 127) << 23) | significand;
+            float sample = FromBits(bits);
+            result[i] = sample;
+        }
+    } else {
+        std::vector<uint64_t> prefix(strata.size());
+        uint64_t total = 0;
+        for (std::size_t i = 0; i < strata.size(); ++i) {
+            total += strata[i].count;
+            prefix[i] = total;
+        }
 
-    int emin = static_cast<int>(std::floor(low));
-    int emax = static_cast<int>(std::ceil(high));
-    int exponent_span = std::max(1, emax - emin);
+        for (int i = 0; i < n; ++i) {
+            double u = unif_rand();
+            double scaled = u * static_cast<double>(total);
+            uint64_t target = static_cast<uint64_t>(scaled);
+            if (target >= total) {
+                target = total - 1;
+            }
 
-    for (int i = 0; i < n; ++i) {
-        float sample;
-        // Draw candidate bits and use the leading-zero count to rotate evenly
-        // through the exponent range before composing the IEEE-754 float.
-        do {
-            int e = emax - 1;
-            uint32_t bits;
-            do {
-                bits = dis(gen);
-            } while (bits == 0);
-            int lz = std::countl_zero(bits);
-            e -= (lz % exponent_span);
+            auto it = std::lower_bound(prefix.begin(), prefix.end(), target + 1);
+            std::size_t idx = static_cast<std::size_t>(it - prefix.begin());
+            const Stratum& st = strata[idx];
 
-            uint32_t significand = dis(gen) & SignificandMask;
-            sample = FromBits((uint32_t(e + 127) << 23) | significand);
-        } while (sample < lower_bound || sample >= upper_bound || !std::isfinite(sample));
-
-        result[i] = sample;
-        // NumericVector stores doubles; assigning the float promotes it back to
-        // R's native type while letting us keep the inner loop in 32-bit math.
+            uint32_t step = sample_offset(st.count);
+            uint32_t significand = st.smin + step;
+            uint32_t bits = (static_cast<uint32_t>(st.exponent + 127) << 23) | significand;
+            float sample = FromBits(bits);
+            result[i] = sample;
+        }
     }
 
     return result;

--- a/tests/testthat/test-bin.R
+++ b/tests/testthat/test-bin.R
@@ -16,6 +16,12 @@ test_that("frsr_bin returns documented columns", {
   expect_identical(unique(result$N_bins), 4L)
 })
 
+test_that("frsr_bin supports weighted sampling", {
+  result <- frsr_bin(float_samples = 8, magic_samples = 8, weighted = TRUE)
+  expect_s3_class(result, "data.frame")
+  expect_true(all(is.finite(unlist(result))))
+})
+
 test_that("frsr_bin handles different number of bins", {
   result <- frsr_bin(n_bins = 2, float_samples = 10, magic_samples = 10)
   expect_equal(nrow(result), 2)

--- a/tests/testthat/test-sample.R
+++ b/tests/testthat/test-sample.R
@@ -1,6 +1,9 @@
 test_that("frsr_sample returns correct number of samples", {
     result <- frsr_sample(4)
     expect_equal(nrow(result), 4)
+
+    weighted_result <- frsr_sample(4, weighted = TRUE)
+    expect_equal(nrow(weighted_result), 4)
 })
 
 test_that("frsr_sample returns parameters when keep_params is TRUE", {
@@ -44,7 +47,8 @@ test_that("boundedStratifiedSample handles narrow exponent ranges", {
         PACKAGE = "frsrr",
         32L,
         low,
-        high
+        high,
+        FALSE
     )
 
     expect_length(samples, 32)
@@ -59,9 +63,26 @@ test_that("boundedStratifiedSample tolerates zero bit draws", {
         PACKAGE = "frsrr",
         1024L,
         log2(0.25),
-        log2(0.5)
+        log2(0.5),
+        FALSE
     )
 
     expect_length(samples, 1024)
     expect_true(all(is.finite(samples)))
+})
+
+test_that("boundedStratifiedSample supports weighted sampling", {
+    samples <- .Call(
+        "_frsrr_boundedStratifiedSample",
+        PACKAGE = "frsrr",
+        64L,
+        log2(0.5),
+        log2(2),
+        TRUE
+    )
+
+    expect_length(samples, 64)
+    expect_true(all(is.finite(samples)))
+    expect_true(all(samples >= 0.5))
+    expect_true(all(samples < 2))
 })


### PR DESCRIPTION
## Summary
- replace the rejection-based float sampler with a strata-driven implementation that respects R's RNG and optionally weights by significand counts
- surface the weighted flag through frsr_sample() and frsr_bin(), including validation and documentation updates
- extend testthat coverage for the new sampler options

## Testing
- Rscript -e "testthat::test_dir('tests/testthat')" *(fails: command not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e50793f548322b1064212cbb3d153)